### PR TITLE
Fixed mod loading crash when launching in data generation environment (Forge 1.19.3)

### DIFF
--- a/src/main/java/pro/mikey/xray/xray/Events.java
+++ b/src/main/java/pro/mikey/xray/xray/Events.java
@@ -2,7 +2,6 @@ package pro.mikey.xray.xray;
 
 import net.minecraft.client.Minecraft;
 import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.client.event.RenderLevelLastEvent;
 import net.minecraftforge.client.event.RenderLevelStageEvent;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.level.BlockEvent;


### PR DESCRIPTION
I'm making a forge mod and I use your mod in order to check the spawn rate of my newly added ores, so it is very convenient.
However I recently started using data generators and I noticed that the mod caused a NPE when loading because it calls `Minecraft.getInstance()`  but it returns null in data environment.

Here is the what the console log would look like:

```
[14:54:16] [modloading-worker-0/ERROR] (FMLModContainer) Failed to create mod instance. ModID: xray, class pro.mikey.xray.XRay
java.lang.reflect.InvocationTargetException: null
	at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77) ~[?:?]
	at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:?]
	at java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499) ~[?:?]
	at java.lang.reflect.Constructor.newInstance(Constructor.java:480) ~[?:?]
	at net.minecraftforge.fml.javafmlmod.FMLModContainer.constructMod(FMLModContainer.java:68) ~[javafmllanguage-1.19.3-44.0.37.jar%23183!/:?]
	at net.minecraftforge.fml.ModContainer.lambda$buildTransitionHandler$10(ModContainer.java:121) ~[fmlcore-1.19.3-44.0.37.jar%23186!/:?]
	at java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1804) ~[?:?]
	at java.util.concurrent.CompletableFuture$AsyncRun.exec(CompletableFuture.java:1796) ~[?:?]
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373) ~[?:?]
	at java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182) ~[?:?]
	at java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655) ~[?:?]
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622) ~[?:?]
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165) ~[?:?]
Caused by: java.lang.ExceptionInInitializerError
	at pro.mikey.xray.ClientController.<clinit>(ClientController.java:25) ~[%23187!/:?]
	at net.minecraftforge.fml.DistExecutor.safeRunWhenOn(DistExecutor.java:123) ~[fmlcore-1.19.3-44.0.37.jar%23186!/:?]
	at pro.mikey.xray.XRay.<init>(XRay.java:20) ~[%23187!/:?]
	... 14 more
Caused by: java.lang.NullPointerException: Cannot read field "gameDirectory" because the return value of "net.minecraft.client.Minecraft.getInstance()" is null
	at pro.mikey.xray.store.DiscoveryStorage.<clinit>(DiscoveryStorage.java:33) ~[%23187!/:?]
	at pro.mikey.xray.ClientController.<clinit>(ClientController.java:25) ~[%23187!/:?]
	at net.minecraftforge.fml.DistExecutor.safeRunWhenOn(DistExecutor.java:123) ~[fmlcore-1.19.3-44.0.37.jar%23186!/:?]
	at pro.mikey.xray.XRay.<init>(XRay.java:20) ~[%23187!/:?]
	... 14 more
[14:54:16] [main/FATAL] (ModLoader) Failed to complete lifecycle event CONSTRUCT, 1 errors found
``` 

I made a commit in this pull request where I make the `STORE_FILE` field in DiscoveryStorage nullable and added non-null checks for every usage.
Let me know what you think.