### PR TITLE
Fix several QoL issues and optimize scan logic

### DIFF
--- a/common/src/main/java/pro/mikey/xray/core/ChunkScanTask.java
+++ b/common/src/main/java/pro/mikey/xray/core/ChunkScanTask.java
@@ -1,27 +1,40 @@
 package pro.mikey.xray.core;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.Fluids;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.List;
 
 public class ChunkScanTask implements Runnable {
     private final Level level;
 
     private final int startX;
     private final int startZ;
+    private final ChunkPos Cpos;
+    private final boolean iscore;
 
-    public ChunkScanTask(Level level, ChunkPos pos) {
+    public ChunkScanTask(Level level, ChunkPos pos, boolean core) {
         // Move the chunk pos to block pos by multiplying by 16
         this.startX = pos.x << 4;
         this.startZ = pos.z << 4;
+        this.Cpos=pos;
 
         this.level = level;
+        this.iscore = core;
+    }
+
+    private boolean isNetherDimension() {
+        ResourceKey<Level> dimensionKey = level.dimension();
+        return dimensionKey == Level.NETHER;
     }
 
     @Override
@@ -39,9 +52,18 @@ public class ChunkScanTask implements Runnable {
                     state = level.getBlockState(pos);
                     fluidState = state.getFluidState();
 
-                    if ((fluidState.getType() == Fluids.LAVA || fluidState.getType() == Fluids.FLOWING_LAVA) && ScanController.INSTANCE.isLavaActive()) {
-                        renderQueue.add(new OutlineRenderTarget(pos.getX(), pos.getY(), pos.getZ(), 0xffff0000));
-                        continue;
+                    if (iscore){
+                        if (( fluidState.getType() == Fluids.LAVA || fluidState.getType() == Fluids.FLOWING_LAVA) && ScanController.INSTANCE.isLavaActive()) {
+                            if (isNetherDimension()) {
+                                if (pos.getY() > 31){
+                                    renderQueue.add(new OutlineRenderTarget(pos.getX(), pos.getY(), pos.getZ(), 0xffff0000));
+                                }
+                            } else {
+                                renderQueue.add(new OutlineRenderTarget(pos.getX(), pos.getY(), pos.getZ(), 0xffff0000));
+                            }
+                            continue;
+                        }
+    
                     }
 
                     // Reject blacklisted blocks
@@ -51,6 +73,7 @@ public class ChunkScanTask implements Runnable {
                     for (var target : ScanController.INSTANCE.scanStore.activeScanTargets()) {
                         if (target.matches(level, pos, state, fluidState)) {
                             renderQueue.add(new OutlineRenderTarget(pos.getX(), pos.getY(), pos.getZ(), target.colorInt()));
+                            break;
                         }
                     }
                 }

--- a/common/src/main/java/pro/mikey/xray/core/OutlineRender.java
+++ b/common/src/main/java/pro/mikey/xray/core/OutlineRender.java
@@ -28,8 +28,10 @@ import java.util.*;
 public class OutlineRender {
 	private static final RenderSystem.AutoStorageIndexBuffer indices = RenderSystem.getSequentialBuffer(VertexFormat.Mode.LINES);
 	private static final Map<ChunkPos, VBOHolder> vertexBuffers = new HashMap<>();
+	private static final Map<ChunkPos, VBOHolder> vertexBuffersa = new HashMap<>();
 
 	private static final Set<ChunkPos> chunksToRefresh = Collections.synchronizedSet(new HashSet<>());
+	private static final Set<ChunkPos> chunksToRefresha = Collections.synchronizedSet(new HashSet<>());
 
 	public static void renderBlocks(PoseStack poseStack) {
 		if (!ScanController.INSTANCE.isXRayActive() || Minecraft.getInstance().player == null) {
@@ -37,92 +39,184 @@ public class OutlineRender {
 		}
 
 		if (ScanController.INSTANCE.syncRenderList.isEmpty()) {
-			return;
-		}
-
-		if (!chunksToRefresh.isEmpty()) {
-			// Clear the vertex buffers for the chunks that need to be refreshed
-			for (ChunkPos pos : chunksToRefresh) {
-				VBOHolder holder = vertexBuffers.remove(pos);
-				if (holder != null) {
-					holder.close();
-				}
-			}
-
-			chunksToRefresh.clear();
-		}
-
-		// Clone the entrySet to avoid concurrent modification exceptions
-		var entries = new ArrayList<>(ScanController.INSTANCE.syncRenderList.entrySet());
-
-		for (var chunkWithBlockData : entries) {
-			var chunkPos = chunkWithBlockData.getKey();
-			var blocksWithProps = chunkWithBlockData.getValue();
-
-			if (blocksWithProps.isEmpty()) {
-				continue;
-			}
-
-			VBOHolder holder = vertexBuffers.get(chunkPos);
-			if (holder == null) {
-				BufferBuilder bufferBuilder = Tesselator.getInstance().begin(RenderPipelines.LINES.getVertexFormatMode(), RenderPipelines.LINES.getVertexFormat());
-
-				// More concurrent modification exceptions can happen here, so we clone the list
-				var blockPropsClone = new ArrayList<>(blocksWithProps);
-
-				for (var blockProps : blockPropsClone) {
-					if (blockProps == null) {
-						continue;
+			//return;
+		} else {
+			if (!chunksToRefresh.isEmpty()) {
+				// Clear the vertex buffers for the chunks that need to be refreshed
+				for (ChunkPos pos : chunksToRefresh) {
+					VBOHolder holder = vertexBuffers.remove(pos);
+					if (holder != null) {
+						holder.close();
 					}
-
-                    final int x = blockProps.x(), y = blockProps.y(), z = blockProps.z();
-
-					ShapeRenderer.renderShape(poseStack, bufferBuilder, Shapes.block(), x, y, z, blockProps.color(), 1f);
 				}
-
-				try (MeshData meshData = bufferBuilder.buildOrThrow()) {
-					int indexCount = meshData.drawState().indexCount();
-					GpuBuffer vertexBuffer = RenderSystem.getDevice()
-							.createBuffer(() -> "Xray vertex buffer", GpuBuffer.USAGE_VERTEX, meshData.vertexBuffer());
-
-					vertexBuffers.put(chunkPos, new VBOHolder(vertexBuffer, indexCount));
+	
+				chunksToRefresh.clear();
+			}
+	
+			// Clone the entrySet to avoid concurrent modification exceptions
+			var entries = new ArrayList<>(ScanController.INSTANCE.syncRenderList.entrySet());
+	
+			for (var chunkWithBlockData : entries) {
+				var chunkPos = chunkWithBlockData.getKey();
+				var blocksWithProps = chunkWithBlockData.getValue();
+	
+				if (blocksWithProps.isEmpty()) {
+					continue;
 				}
+	
+				VBOHolder holder = vertexBuffers.get(chunkPos);
+				if (holder == null) {
+					BufferBuilder bufferBuilder = Tesselator.getInstance().begin(RenderPipelines.LINES.getVertexFormatMode(), RenderPipelines.LINES.getVertexFormat());
+	
+					// More concurrent modification exceptions can happen here, so we clone the list
+					var blockPropsClone = new ArrayList<>(blocksWithProps);
+	
+					for (var blockProps : blockPropsClone) {
+						if (blockProps == null) {
+							continue;
+						}
+	
+						final int x = blockProps.x(), y = blockProps.y(), z = blockProps.z();
+	
+						ShapeRenderer.renderShape(poseStack, bufferBuilder, Shapes.block(), x, y, z, blockProps.color(), 1f);
+					}
+	
+					try (MeshData meshData = bufferBuilder.buildOrThrow()) {
+						int indexCount = meshData.drawState().indexCount();
+						GpuBuffer vertexBuffer = RenderSystem.getDevice()
+								.createBuffer(() -> "Xray vertex buffer", GpuBuffer.USAGE_VERTEX, meshData.vertexBuffer());
+	
+						vertexBuffers.put(chunkPos, new VBOHolder(vertexBuffer, indexCount));
+					}
+				}
+	
+				holder = vertexBuffers.get(chunkPos);
+				if (holder == null || holder.vertexBuffer == null || holder.indexCount == 0) {
+					continue;
+				}
+	
+				Vec3 playerPos = Minecraft.getInstance().gameRenderer.getMainCamera().position().reverse();
+	
+				Matrix4fStack matrix4fStack = RenderSystem.getModelViewStack();
+				GpuTextureView colorTextureView = Minecraft.getInstance().getMainRenderTarget().getColorTextureView();
+				GpuTextureView depthTextureView = Minecraft.getInstance().getMainRenderTarget().getDepthTextureView();
+	
+				matrix4fStack.pushMatrix();
+				matrix4fStack.translate((float) playerPos.x(), (float) playerPos.y(), (float) playerPos.z());
+				GpuBufferSlice[] gpubufferslice = RenderSystem.getDynamicUniforms().writeTransforms(new DynamicUniforms.Transform(new Matrix4f(matrix4fStack), new Vector4f(1.0F, 1.0F, 1.0F, 1.0F), new Vector3f(), new Matrix4f()));
+	
+				GL11.glDisable(GL11.GL_DEPTH_TEST);
+				RenderSystem.setShaderFog(gpubufferslice[0]);
+	
+				GpuBuffer gpuBuffer = indices.getBuffer(holder.indexCount);
+				try (RenderPass renderPass = RenderSystem.getDevice()
+						.createCommandEncoder()
+						.createRenderPass(() -> "xray", colorTextureView, OptionalInt.empty(), depthTextureView, OptionalDouble.empty())) {
+	
+					RenderSystem.bindDefaultUniforms(renderPass);
+					renderPass.setVertexBuffer(0, holder.vertexBuffer);
+					renderPass.setIndexBuffer(gpuBuffer, indices.type());
+					renderPass.setUniform("DynamicTransforms", gpubufferslice[0]);
+					renderPass.setPipeline(RenderPipelines.LINES);
+					renderPass.drawIndexed(0, 0, holder.indexCount, 1);
+				}
+	
+				GL11.glEnable(GL11.GL_DEPTH_TEST);
+				matrix4fStack.popMatrix();
 			}
-
-			holder = vertexBuffers.get(chunkPos);
-			if (holder == null || holder.vertexBuffer == null || holder.indexCount == 0) {
-				continue;
-			}
-
-			Vec3 playerPos = Minecraft.getInstance().gameRenderer.getMainCamera().position().reverse();
-
-			Matrix4fStack matrix4fStack = RenderSystem.getModelViewStack();
-			GpuTextureView colorTextureView = Minecraft.getInstance().getMainRenderTarget().getColorTextureView();
-			GpuTextureView depthTextureView = Minecraft.getInstance().getMainRenderTarget().getDepthTextureView();
-
-			matrix4fStack.pushMatrix();
-			matrix4fStack.translate((float) playerPos.x(), (float) playerPos.y(), (float) playerPos.z());
-			GpuBufferSlice[] gpubufferslice = RenderSystem.getDynamicUniforms().writeTransforms(new DynamicUniforms.Transform(new Matrix4f(matrix4fStack), new Vector4f(1.0F, 1.0F, 1.0F, 1.0F), new Vector3f(), new Matrix4f()));
-
-            GL11.glDisable(GL11.GL_DEPTH_TEST);
-            RenderSystem.setShaderFog(gpubufferslice[0]);
-
-			GpuBuffer gpuBuffer = indices.getBuffer(holder.indexCount);
-			try (RenderPass renderPass = RenderSystem.getDevice()
-					.createCommandEncoder()
-					.createRenderPass(() -> "xray", colorTextureView, OptionalInt.empty(), depthTextureView, OptionalDouble.empty())) {
-
-				RenderSystem.bindDefaultUniforms(renderPass);
-				renderPass.setVertexBuffer(0, holder.vertexBuffer);
-				renderPass.setIndexBuffer(gpuBuffer, indices.type());
-				renderPass.setUniform("DynamicTransforms", gpubufferslice[0]);
-				renderPass.setPipeline(RenderPipelines.LINES);
-				renderPass.drawIndexed(0, 0, holder.indexCount, 1);
-			}
-
-            GL11.glEnable(GL11.GL_DEPTH_TEST);
-            matrix4fStack.popMatrix();
 		}
+
+		//
+		if (ScanController.INSTANCE.syncRenderLista.isEmpty()) {
+			return;
+		} else {
+			if (!chunksToRefresha.isEmpty()) {
+				// Clear the vertex buffers for the chunks that need to be refreshed
+				for (ChunkPos pos : chunksToRefresha) {
+					VBOHolder holder = vertexBuffersa.remove(pos);
+					if (holder != null) {
+						holder.close();
+					}
+				}
+	
+				chunksToRefresha.clear();
+			}
+	
+			// Clone the entrySet to avoid concurrent modification exceptions
+			var entries = new ArrayList<>(ScanController.INSTANCE.syncRenderLista.entrySet());
+	
+			for (var chunkWithBlockData : entries) {
+				var chunkPos = chunkWithBlockData.getKey();
+				var blocksWithProps = chunkWithBlockData.getValue();
+	
+				if (blocksWithProps.isEmpty()) {
+					continue;
+				}
+	
+				VBOHolder holder = vertexBuffersa.get(chunkPos);
+				if (holder == null) {
+					BufferBuilder bufferBuilder = Tesselator.getInstance().begin(RenderPipelines.LINES.getVertexFormatMode(), RenderPipelines.LINES.getVertexFormat());
+	
+					// More concurrent modification exceptions can happen here, so we clone the list
+					var blockPropsClone = new ArrayList<>(blocksWithProps);
+	
+					for (var blockProps : blockPropsClone) {
+						if (blockProps == null) {
+							continue;
+						}
+	
+						final int x = blockProps.x(), y = blockProps.y(), z = blockProps.z();
+	
+						ShapeRenderer.renderShape(poseStack, bufferBuilder, Shapes.block(), x, y, z, blockProps.color(), 1f);
+					}
+	
+					try (MeshData meshData = bufferBuilder.buildOrThrow()) {
+						int indexCount = meshData.drawState().indexCount();
+						GpuBuffer vertexBuffer = RenderSystem.getDevice()
+								.createBuffer(() -> "Xray vertex buffer", GpuBuffer.USAGE_VERTEX, meshData.vertexBuffer());
+	
+						vertexBuffersa.put(chunkPos, new VBOHolder(vertexBuffer, indexCount));
+					}
+				}
+	
+				holder = vertexBuffersa.get(chunkPos);
+				if (holder == null || holder.vertexBuffer == null || holder.indexCount == 0) {
+					continue;
+				}
+	
+				Vec3 playerPos = Minecraft.getInstance().gameRenderer.getMainCamera().position().reverse();
+	
+				Matrix4fStack matrix4fStack = RenderSystem.getModelViewStack();
+				GpuTextureView colorTextureView = Minecraft.getInstance().getMainRenderTarget().getColorTextureView();
+				GpuTextureView depthTextureView = Minecraft.getInstance().getMainRenderTarget().getDepthTextureView();
+	
+				matrix4fStack.pushMatrix();
+				matrix4fStack.translate((float) playerPos.x(), (float) playerPos.y(), (float) playerPos.z());
+				GpuBufferSlice[] gpubufferslice = RenderSystem.getDynamicUniforms().writeTransforms(new DynamicUniforms.Transform(new Matrix4f(matrix4fStack), new Vector4f(1.0F, 1.0F, 1.0F, 1.0F), new Vector3f(), new Matrix4f()));
+	
+				GL11.glDisable(GL11.GL_DEPTH_TEST);
+				RenderSystem.setShaderFog(gpubufferslice[0]);
+	
+				GpuBuffer gpuBuffer = indices.getBuffer(holder.indexCount);
+				try (RenderPass renderPass = RenderSystem.getDevice()
+						.createCommandEncoder()
+						.createRenderPass(() -> "xray", colorTextureView, OptionalInt.empty(), depthTextureView, OptionalDouble.empty())) {
+	
+					RenderSystem.bindDefaultUniforms(renderPass);
+					renderPass.setVertexBuffer(0, holder.vertexBuffer);
+					renderPass.setIndexBuffer(gpuBuffer, indices.type());
+					renderPass.setUniform("DynamicTransforms", gpubufferslice[0]);
+					renderPass.setPipeline(RenderPipelines.LINES);
+					renderPass.drawIndexed(0, 0, holder.indexCount, 1);
+				}
+	
+				GL11.glEnable(GL11.GL_DEPTH_TEST);
+				matrix4fStack.popMatrix();
+			}
+		}
+
+
+
 	}
 
 	public static void clearVBOs() {
@@ -132,6 +226,12 @@ public class OutlineRender {
 			}
 		}
 		vertexBuffers.clear();
+		for (VBOHolder holder : vertexBuffersa.values()) {
+			if (holder != null) {
+				holder.close();
+			}
+		}
+		vertexBuffersa.clear();
 	}
 
 	public static void clearVBOsFor(List<ChunkPos> removedChunks) {
@@ -144,6 +244,10 @@ public class OutlineRender {
 
 	public static void refreshVBOForChunk(ChunkPos pos) {
 		chunksToRefresh.add(pos);
+	}
+
+	public static void refreshVBOForChunka(ChunkPos pos) {
+		chunksToRefresha.add(pos);
 	}
 
 	private record VBOHolder(GpuBuffer vertexBuffer, int indexCount) implements Closeable {

--- a/common/src/main/java/pro/mikey/xray/core/ScanController.java
+++ b/common/src/main/java/pro/mikey/xray/core/ScanController.java
@@ -18,6 +18,8 @@ import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 public enum ScanController {
     INSTANCE;
@@ -45,8 +47,13 @@ public enum ScanController {
     }};
 
 
-    public final Map<ChunkPos, Set<OutlineRenderTarget>> syncRenderList = Collections.synchronizedMap(new HashMap<>()); // this is accessed by threads
+    public final Map<ChunkPos, Set<OutlineRenderTarget>> syncRenderList = new ConcurrentHashMap<>(); // this is accessed by threads
+    public final Map<ChunkPos, Set<OutlineRenderTarget>> syncRenderLista = new ConcurrentHashMap<>(); // this is accessed by threads
     private ChunkPos lastChunkPos = null;
+    private BlockPos lastPos = null;
+    private Set<ChunkPos> last3x3 = ConcurrentHashMap.newKeySet();
+    private Set<ChunkPos> lastxxx = ConcurrentHashMap.newKeySet();
+    private List<BlockPos> lastshi = new ArrayList<>();
 
     public final ScanStore scanStore = new ScanStore();
 
@@ -74,6 +81,9 @@ public enum ScanController {
         if (!xrayActive) // enable drawing
         {
             syncRenderList.clear(); // first, clear the buffer
+            syncRenderLista.clear(); // first, clear the buffer
+            last3x3.clear();
+            lastxxx.clear();
             xrayActive = true; // then, enable drawing
             requestBlockFinder(true); // finally, force a refresh
 
@@ -108,11 +118,8 @@ public enum ScanController {
         return Math.max(1, getRadius());
     }
 
-    public void incrementCurrentDist() {
-        if (XRay.config().radius.get() < maxStepsToScan)
-            XRay.config().radius.set(XRay.config().radius.get() + 1);
-        else
-            XRay.config().radius.set(0);
+    public void incrementCurrentDist(int value) {
+            XRay.config().radius.set(value);
     }
 
     public void decrementCurrentDist() {
@@ -131,8 +138,39 @@ public enum ScanController {
         return lastChunkPos == null || !lastChunkPos.equals(plyChunkPos);
     }
 
+    private boolean playerHasMoveda() {
+        if (Minecraft.getInstance().player == null)
+            return false;
+        BlockPos plyChunkPos = Minecraft.getInstance().player.blockPosition();
+        return lastPos == null || !lastPos.equals(plyChunkPos);
+    }
+
     private void updatePlayerPosition() {
         lastChunkPos = Minecraft.getInstance().player.chunkPosition();
+    }
+
+    private void updatePlayerPositiona() {
+        lastPos = Minecraft.getInstance().player.blockPosition();
+    }
+
+    private List<ChunkPos> getCore3x3Chunks(ChunkPos playerChunk,int range) {
+    List<ChunkPos> coreChunks = new ArrayList<>();
+    if (range==0){
+        coreChunks.add(new ChunkPos(playerChunk.x, playerChunk.z));
+    } else {
+        for (int x = playerChunk.x - 1; x <= playerChunk.x + 1; x++) {
+            for (int z = playerChunk.z - 1; z <= playerChunk.z + 1; z++) {
+                coreChunks.add(new ChunkPos(x, z));
+            }
+        }
+    }
+        return coreChunks;
+    }
+
+    private List<ChunkPos> getOuterChunks(List<ChunkPos> allChunks, List<ChunkPos> core3x3Chunks) {
+        return allChunks.stream()
+            .filter(chunk -> !core3x3Chunks.contains(chunk))
+            .collect(Collectors.toList());
     }
 
     public synchronized void requestBlockFinder(boolean force) {
@@ -147,6 +185,9 @@ public enum ScanController {
             if (force) {
                 // Clear the render list if we are forcing a scan
                 syncRenderList.clear();
+                syncRenderLista.clear();
+                last3x3.clear();
+                lastxxx.clear();
                 OutlineRender.clearVBOs(); // Clear the VBOs as well
             }
 
@@ -167,11 +208,32 @@ public enum ScanController {
             // Sort the chunks by distance to the player
             chunksToScan.sort(Comparator.comparingDouble(chunk -> chunk.distanceSquared(playerChunkPos)));
 
-            var knownChunks = syncRenderList.keySet();
+            List<ChunkPos> core3x3Chunks = getCore3x3Chunks(playerChunkPos,range);
+            List<ChunkPos> outerChunks = getOuterChunks(chunksToScan, core3x3Chunks);
+
+            var knownChunksa = last3x3;
+
+            var newChunksa = core3x3Chunks.stream().filter(chunk -> !knownChunksa.contains(chunk)).toList();
+            var removedChunksa = knownChunksa.stream().filter(chunk -> !core3x3Chunks.contains(chunk)).toList();
+
+            if (!removedChunksa.isEmpty()) {
+                OutlineRender.clearVBOsFor(removedChunksa);
+            }
+            for (ChunkPos chunk : removedChunksa) {
+                last3x3.remove(chunk);
+                syncRenderList.remove(chunk);
+            }
+
+            for (ChunkPos chunk : newChunksa) {
+                last3x3.add(chunk);
+                SCANNER.submit(new ChunkScanTask(player.level(), chunk, true));
+            }
+
+            var knownChunks = lastxxx;
 
             // New chunks
-            var newChunks = chunksToScan.stream().filter(chunk -> !knownChunks.contains(chunk)).toList();
-            var removedChunks = knownChunks.stream().filter(chunk -> !chunksToScan.contains(chunk)).toList();
+            var newChunks = outerChunks.stream().filter(chunk -> !knownChunks.contains(chunk)).toList();
+            var removedChunks = knownChunks.stream().filter(chunk -> !outerChunks.contains(chunk)).toList();
 
             if (!removedChunks.isEmpty()) {
                 OutlineRender.clearVBOsFor(removedChunks);
@@ -179,13 +241,71 @@ public enum ScanController {
 
             // Push the new chunks to the scanner, remove the old ones from the render list
             for (ChunkPos chunk : removedChunks) {
+                lastxxx.remove(chunk);
                 syncRenderList.remove(chunk);
             }
 
             for (ChunkPos chunk : newChunks) {
-                SCANNER.submit(new ChunkScanTask(player.level(), chunk));
+                lastxxx.add(chunk);
+                SCANNER.submit(new ChunkScanTask(player.level(), chunk, false));
             }
         }
+
+        if (isXRayActive() && (force || playerHasMoveda())) {
+            updatePlayerPositiona();
+            clean();
+            add();
+        }
+    }
+
+    public synchronized void clean(){
+        if (lastshi != null && !lastshi.isEmpty()) {
+            Set<OutlineRenderTarget> renderQueuea = new HashSet<>();
+            for (BlockPos chunk : lastshi){
+                renderQueuea.add(new OutlineRenderTarget(chunk.getX(), chunk.getY(), chunk.getZ(), 0xffff00ff));
+            }
+            var re=ScanController.INSTANCE.syncRenderLista.get(new ChunkPos(1, 1));
+            if (re != null){
+                re.removeAll(renderQueuea);
+            }
+            OutlineRender.refreshVBOForChunka(new ChunkPos(1, 1));
+        }
+    }
+
+    public synchronized void add(){
+        BlockPos playerChunkPos = Minecraft.getInstance().player.blockPosition();
+        List<BlockPos> chunksToScan = new ArrayList<>();
+        for (int z = playerChunkPos.getZ() - 5; z <= playerChunkPos.getZ() + 5; z++) {
+            if (z != playerChunkPos.getZ()) {
+                chunksToScan.add(new BlockPos(playerChunkPos.getX(),playerChunkPos.getY()-1, z));
+            } else {
+                chunksToScan.add(new BlockPos(playerChunkPos.getX(),playerChunkPos.getY()+3, z));
+                chunksToScan.add(new BlockPos(playerChunkPos.getX(),playerChunkPos.getY()-2, z));
+                chunksToScan.add(new BlockPos(playerChunkPos.getX(),playerChunkPos.getY()-3, z));
+                chunksToScan.add(new BlockPos(playerChunkPos.getX(),playerChunkPos.getY()-4, z));
+            }
+        };
+        for (int x = playerChunkPos.getX() - 5; x <= playerChunkPos.getX() + 5; x++) {
+            if (x != playerChunkPos.getX()) {
+                chunksToScan.add(new BlockPos(x,playerChunkPos.getY()-1 ,playerChunkPos.getZ()));
+            }
+        };
+        Set<OutlineRenderTarget> renderQueue = new HashSet<>();
+        for (BlockPos chunk : chunksToScan){
+            BlockState state = Minecraft.getInstance().player.level().getBlockState(chunk);
+            if (chunk.getY()==playerChunkPos.getY()+3) {
+                if ((state.getBlock() ==  Blocks.SAND || state.getBlock() ==  Blocks.GRAVEL) && ScanController.INSTANCE.isLavaActive()) {
+                    renderQueue.add(new OutlineRenderTarget(chunk.getX(), chunk.getY(), chunk.getZ(), 0xffff00ff));
+                    ScanController.INSTANCE.syncRenderLista.put(new ChunkPos(1, 1), renderQueue);
+                }
+            } else {
+                if ((state.getBlock() ==  Blocks.AIR || state.getBlock() ==  Blocks.CAVE_AIR|| state.getBlock() ==  Blocks.POWDER_SNOW) && ScanController.INSTANCE.isLavaActive()) {
+                    renderQueue.add(new OutlineRenderTarget(chunk.getX(), chunk.getY(), chunk.getZ(), 0xffff00ff));
+                    ScanController.INSTANCE.syncRenderLista.put(new ChunkPos(1, 1), renderQueue);
+                }
+            }
+        }
+        lastshi=new ArrayList<>(chunksToScan);
     }
 
     public static void onBlockChange(Level level, BlockPos pos, BlockState state) {
@@ -208,16 +328,21 @@ public enum ScanController {
                 // We need to tell the outline render to refresh the VBO for this chunk
                 OutlineRender.refreshVBOForChunk(chunkPos);
             }
-
+            INSTANCE.clean();
+            INSTANCE.add();
             return;
         }
 
         if (ScanController.INSTANCE.isLavaActive() && state.is(Blocks.LAVA)) {
             // We're actively looking at this chunk so let's inject this block
-            outlineRenderTargets.add(new OutlineRenderTarget(pos.getX(), pos.getY(), pos.getZ(), 0xff0000));
+            outlineRenderTargets.add(new OutlineRenderTarget(pos.getX(), pos.getY(), pos.getZ(), 0xffff0000));
 
             // Tell the VBO to refresh for this chunk
             OutlineRender.refreshVBOForChunk(chunkPos);
+            
+            INSTANCE.clean();
+            INSTANCE.add();
+            return;
         }
 
         // Otherwise, do we have scantarget in the active list of things to find?
@@ -233,6 +358,9 @@ public enum ScanController {
                 // Tell the VBO to refresh for this chunk
                 OutlineRender.refreshVBOForChunk(chunkPos);
                 noMatchesFound = false; // We found a match, so we can stop checking
+                
+                INSTANCE.clean();
+                INSTANCE.add();
                 break; // We found a match, so we can stop checking
             }
         }
@@ -243,6 +371,8 @@ public enum ScanController {
                 .findFirst();
 
         if (blockFromRenderList.isEmpty()) {
+            INSTANCE.clean();
+            INSTANCE.add();
             return;
         }
 

--- a/common/src/main/java/pro/mikey/xray/core/scanner/BlockScanType.java
+++ b/common/src/main/java/pro/mikey/xray/core/scanner/BlockScanType.java
@@ -41,4 +41,9 @@ public class BlockScanType extends ScanType {
     void writeData(JsonObject obj) {
         obj.addProperty("block_name", this.blockName);
     }
+    
+    @Override
+    public Block getBlock() {
+        return this.block;
+    }
 }

--- a/common/src/main/java/pro/mikey/xray/core/scanner/ScanStore.java
+++ b/common/src/main/java/pro/mikey/xray/core/scanner/ScanStore.java
@@ -182,7 +182,25 @@ public class ScanStore {
                 if (!scanType.enabled) {
                     continue; // Skip disabled scan types
                 }
-
+                
+                if (scanType.getBlock()==Blocks.WHITE_BED){
+                    this.activeScanTargets.add(new BlockScanType(Blocks.WHITE_BED, "", scanType.color(), 0));
+                    this.activeScanTargets.add(new BlockScanType(Blocks.ORANGE_BED, "", scanType.color(), 0));
+                    this.activeScanTargets.add(new BlockScanType(Blocks.MAGENTA_BED, "", scanType.color(), 0));
+                    this.activeScanTargets.add(new BlockScanType(Blocks.LIGHT_BLUE_BED, "", scanType.color(), 0));
+                    this.activeScanTargets.add(new BlockScanType(Blocks.YELLOW_BED, "", scanType.color(), 0));
+                    this.activeScanTargets.add(new BlockScanType(Blocks.LIME_BED, "", scanType.color(), 0));
+                    this.activeScanTargets.add(new BlockScanType(Blocks.PINK_BED, "", scanType.color(), 0));
+                    this.activeScanTargets.add(new BlockScanType(Blocks.GRAY_BED, "", scanType.color(), 0));
+                    this.activeScanTargets.add(new BlockScanType(Blocks.LIGHT_GRAY_BED, "", scanType.color(), 0));
+                    this.activeScanTargets.add(new BlockScanType(Blocks.CYAN_BED, "", scanType.color(), 0));
+                    this.activeScanTargets.add(new BlockScanType(Blocks.PURPLE_BED, "", scanType.color(), 0));
+                    this.activeScanTargets.add(new BlockScanType(Blocks.BLUE_BED, "", scanType.color(), 0));
+                    this.activeScanTargets.add(new BlockScanType(Blocks.BROWN_BED, "", scanType.color(), 0));
+                    this.activeScanTargets.add(new BlockScanType(Blocks.GREEN_BED, "", scanType.color(), 0));
+                    this.activeScanTargets.add(new BlockScanType(Blocks.RED_BED, "", scanType.color(), 0));
+                    this.activeScanTargets.add(new BlockScanType(Blocks.BLACK_BED, "", scanType.color(), 0));
+                }
                 this.activeScanTargets.add(scanType);
             }
         }

--- a/common/src/main/java/pro/mikey/xray/core/scanner/ScanType.java
+++ b/common/src/main/java/pro/mikey/xray/core/scanner/ScanType.java
@@ -7,6 +7,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.FluidState;
 import pro.mikey.xray.XRay;
+import net.minecraft.world.level.block.Block;
 
 import java.awt.*;
 import java.util.Set;
@@ -247,5 +248,9 @@ public abstract class ScanType {
         public Identifier getId() {
             return id;
         }
+    }
+    
+    public Block getBlock() {
+        return null;
     }
 }

--- a/common/src/main/java/pro/mikey/xray/screens/ScanManageScreen.java
+++ b/common/src/main/java/pro/mikey/xray/screens/ScanManageScreen.java
@@ -3,6 +3,7 @@ package pro.mikey.xray.screens;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.AbstractSliderButton;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.gui.components.ObjectSelectionList;
@@ -14,6 +15,7 @@ import net.minecraft.client.renderer.entity.ItemRenderer;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
+import net.minecraft.util.Mth;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.BlockItem;
@@ -151,15 +153,26 @@ public class ScanManageScreen extends GuiBase {
                 .build());
 
         
-        addRenderableWidget(distButtons = Button.builder(Component.translatable("xray.input.distance", ScanController.INSTANCE.getVisualRadius()), btn -> {
-            ScanController.INSTANCE.incrementCurrentDist();
-            btn.setMessage(Component.translatable("xray.input.distance", ScanController.INSTANCE.getVisualRadius()));
-        })
-                .pos(getWidth() / 2 + 79, getHeight() / 2 + 36)
-                .size(120, 20)
-                .tooltip(Tooltip.create(Component.translatable("xray.tooltips.distance")))
-                .build()
-        );
+        AbstractSliderButton radiusSlider = new AbstractSliderButton(
+            getWidth() / 2 + 79, getHeight() / 2 + 36, 120, 20,
+            Component.translatable("xray.input.distance", ScanController.INSTANCE.getVisualRadius()),
+            Mth.map(XRay.config().radius.get(), 0, 5, 0.0, 1.0)
+        ) {
+            @Override
+            protected void updateMessage() {
+                int currentRadiusp = Mth.floor(Mth.map(this.value, 0.0, 1.0, 0, 5))    ;
+                int currentRadius = Math.max(1, currentRadiusp * 3);
+                    this.setMessage(Component.translatable("xray.input.distance", currentRadius));
+            }
+
+            @Override
+            protected void applyValue() {
+                int currentRadius = Mth.floor(Mth.map(this.value, 0.0, 1.0, 0, 5));
+                ScanController.INSTANCE.incrementCurrentDist(currentRadius);
+            }
+        };
+        radiusSlider.setTooltip(Tooltip.create(Component.translatable("xray.tooltips.distance")));
+        addRenderableWidget(radiusSlider);
 
         addRenderableWidget(
             Button.builder(Component.translatable("xray.single.help"), button -> {


### PR DESCRIPTION
After one month of in-game playtesting, I have added relevant code to fix several quality-of-life issues:
All colored beds need to be added to the scan list when attempting to remove all beds in a village.
Character falling occurs when tunneling forward rapidly in the Nether.
Character falling occurs when tunneling downward rapidly in the Overworld.
Character getting buried when tunneling upward rapidly in the Overworld.
Lava lakes below Y31 in the Nether block the field of view.
Lava waterfalls block the field of view when scanning at a distance of 15 in the Nether.
Inconvenience in adjusting the scanning distance.
Character falling into powder snow pits while wandering in snowy biomes.
In addition, several minor glitches have been fixed. For example, manually placed lava was not added to the scan (the original code seems to have intended to include manually placed lava in the scan).
Note: The above content was initially translated via a translation tool. My apologies if there was any inappropriate expression.
Disclaimer: My coding skills are still quite basic. If you are willing, I would greatly appreciate it if you could help polish or modify the code to make it more robust and standardized.